### PR TITLE
Refactor Hermite, add SLDHermite subclass

### DIFF
--- a/molgroups.py
+++ b/molgroups.py
@@ -1782,7 +1782,7 @@ class SLDHermite(Hermite):
         return sld
 
     def fnSetnSLD(self, dnSLD): 
-        self.nSLD = dnSLD
+        self.nSLD = None
 
     def fnSetRelative(self, dSpacing, dStart, dDp, dVf, dnSLD, dnf):
         self.vf = numpy.array(dVf)


### PR DESCRIPTION
Hermite has been refactored to allow more natural subclassing for SLDHermite and to improve calculation efficiency. The behavior has changed in the following significant ways:
1. All of the initialization parameters except normarea have been removed. This is because fnSetRelative was already required to populate the important attributes. For Hermite, nSLD (a constant) has been added to fnSetRelative.
2. The function calls for fnSetRelative for Hermite and SLDHermite now look exactly the same. The only difference is that Hermite expects a constant for dnSLD and SLDHermite expects a list of control points.
3. The area (and SLD) spline interpolators are now stored in the object after calling fnSetRelative, instead of being created on the fly (presumably slower) when calling fnGetProfiles. This means that if anything is changed (damping parameters, for example), fnSetRelative needs to be called again for them to be updated.
4. The antiderivative (integral) is now also stored in the object, and fnGetVolume now takes endpoints z1 and z2 for the integration again.

This way the spline interpolators don't need to be redefined all the time, and the integration is a straightforward call to the stored antiderivative function.

Finally, SLDHermite has been implemented as a subclass of Hermite.