### PR TITLE
Lipid library changes

### DIFF
--- a/lipids.py
+++ b/lipids.py
@@ -51,12 +51,8 @@ class Lipid(object):
             TypeError('Lipid.tails must be Molecule or list of Molecules')
         
         self.hg = hg
-        if isinstance(hg, Molecule):
-            hg_volume = hg.cell_volume
-        elif isinstance(hg, CompositenSLDObj):
-            hg_volume = sum([g.vol for g in hg.subgroups])
-        else:
-            TypeError('Lipid.hg must be Headgroup or CompositenSLDObj')
+        assert(isinstance(hg, Molecule) | isinstance(hg, CompositenSLDObj))
+        TypeError('Lipid.hg must be Headgroup or CompositenSLDObj')
 
 if __name__ == '__main__':
     dopc = Lipid()

--- a/lipids.py
+++ b/lipids.py
@@ -1,37 +1,65 @@
 from periodictable.fasta import Molecule
 from molgroups import CompositenSLDObj
-# in formulas, use T for exchangeable hydrogens, then Molecule.D2Osld(D2O_fraction=1) to get D2O SLD.
-pc = Molecule(name='pc', formula='C10 H18 O8 N P', cell_volume=331.00)
+# in formulas, use H[1] for exchangeable hydrogens, then Molecule.sld, Molecule.Dsld
+# to get limiting slds, or Molecule.D2Osld(D2O_fraction=??) to get arbitrary D2O fraction.
+
+class Headgroup(Molecule):
+    # Subclasses Molecule to automatically store a headgroup length for use later
+    # and calculate total scattering lengths
+    def __init__(self, length=9.575, **kwargs):
+        super().__init__(**kwargs)
+        self.length = length
+        self.nSL = self.sld * self.cell_volume * 1e-6 # units of Ang
+        self.DnSL = self.Dsld * self.cell_volume * 1e-6 # units of Ang
+
+# headgroup pieces
+choline = Molecule(name='choline', formula='C5 H13 N', cell_volume=120.)
+phosphate = Molecule(name='phosphate', formula='PO4', cell_volume=54.)
+carbonyl_glycerol = Molecule(name='carbonyl + glycerol', formula='C5 O4 H5', cell_volume=147.)
+
+# headgroups
+pc = Headgroup(name='pc', formula='C10 H18 O8 N P', cell_volume=331.00, length=9.575)
+pe = Headgroup(name='pe', formula='C7 H9 H[1]3 O8 N P', cell_volume=262., length=7.7)
+pg = Headgroup(name='pg', formula='C8 H10 H[1]2 O10 P', cell_volume=240., length=7.8)
+ps = Headgroup(name='ps', formula='C8 H8 H[1]3 N O10 P', cell_volume=280., length=8.1)
+pa = Headgroup(name='pa', formula='C5 H5 H[1] O8 P', cell_volume=174., length=5.0)
+pi = Headgroup(name='pi', formula='C11 H7 H[1]5 O13 P', cell_volume=370.7, length=10.7)
+pip2 = Headgroup(name='pi(4,5)p2', formula='C11 H7 H[1]5 O19 P3', cell_volume=500., length=12.0) # doesn't match molgroups.cc
+cardiolipin = Headgroup(name='cardiolipin', formula='C13 H15 H[1] O17 P2', cell_volume=684.4, length=9.56)
+
 oleoyl = Molecule(name='oleoyl', formula='C17 H33', cell_volume=474.90/2.0)
+palmitoyl = Molecule(name='palmitoyl', formula='C15 H31', cell_volume=770./2.0)
+myristoyl = Molecule(name='myristoyl', formula='C13 H27', cell_volume=770./2.0)
+phytanoyl = Molecule(name='phytanoyl', formula='C19 H39', cell_volume=1095./2.0)
+
+# TODO: make a Tether class that can be passed to tethered bilayers. Perhaps make Tether class none for supported bilayers?
 
 class Lipid(object):
-    def __init__(self, name=None, hg=pc, tails=[oleoyl, oleoyl]):
-        # hg = Molecule object with headgroup information or molgroups object
+    def __init__(self, name=None, hg=pc, tails=[oleoyl, oleoyl], **kwargs):
+        # hg = Molecule object with headgroup information or PC molgroups object
         # tails = List of molecule objects containing lipid tail information
         # default is DOPC
-
-        # TODO: should Box2Errs be created here, or in the __init__ of the BLM object?
-
-        # hg section
-        if isinstance(hg, Molecule):
-            self.hg = hg
-        elif isinstance(hg, CompositenSLDObj):
-            # do other stuff?
-            self.hg = hg
-        
+       
         # tails section
-        total_volume = sum([t.cell_volume for t in tails])
+        tail_volume = sum([t.cell_volume for t in tails])
         if isinstance(tails, list):
-            total_formula = ' '.join([str(t.formula) for t in tails])
-            self.tails = Molecule(name='tails',formula=total_formula, cell_volume=total_volume)
+            tail_formula = ' '.join([str(t.formula) for t in tails])
+            self.tails = Molecule(name='tails',formula=tail_formula, cell_volume=tail_volume)
         elif isinstance(tails, Molecule):
             self.tails = tails
         else:
             TypeError('Lipid.tails must be Molecule or list of Molecules')
         
         self.hg = hg
+        if isinstance(hg, Molecule):
+            hg_volume = hg.cell_volume
+        elif isinstance(hg, CompositenSLDObj):
+            hg_volume = sum([g.vol for g in hg.subgroups])
+        else:
+            TypeError('Lipid.hg must be Headgroup or CompositenSLDObj')
 
-dopc = Lipid()
-nSL, nSL2 = dopc.hg.Hsld * dopc.hg.cell_volume, dopc.hg.Dsld * dopc.hg.cell_volume
-print(nSL, nSL2)
+if __name__ == '__main__':
+    dopc = Lipid()
+    nSL, nSL2 = dopc.hg.sld * dopc.hg.cell_volume, dopc.hg.Dsld * dopc.hg.cell_volume
+    print(nSL, nSL2)
 

--- a/lipids.py
+++ b/lipids.py
@@ -1,0 +1,37 @@
+from periodictable.fasta import Molecule
+from molgroups import CompositenSLDObj
+# in formulas, use T for exchangeable hydrogens, then Molecule.D2Osld(D2O_fraction=1) to get D2O SLD.
+pc = Molecule(name='pc', formula='C10 H18 O8 N P', cell_volume=331.00)
+oleoyl = Molecule(name='oleoyl', formula='C17 H33', cell_volume=474.90/2.0)
+
+class Lipid(object):
+    def __init__(self, name=None, hg=pc, tails=[oleoyl, oleoyl]):
+        # hg = Molecule object with headgroup information or molgroups object
+        # tails = List of molecule objects containing lipid tail information
+        # default is DOPC
+
+        # TODO: should Box2Errs be created here, or in the __init__ of the BLM object?
+
+        # hg section
+        if isinstance(hg, Molecule):
+            self.hg = hg
+        elif isinstance(hg, CompositenSLDObj):
+            # do other stuff?
+            self.hg = hg
+        
+        # tails section
+        total_volume = sum([t.cell_volume for t in tails])
+        if isinstance(tails, list):
+            total_formula = ' '.join([str(t.formula) for t in tails])
+            self.tails = Molecule(name='tails',formula=total_formula, cell_volume=total_volume)
+        elif isinstance(tails, Molecule):
+            self.tails = tails
+        else:
+            TypeError('Lipid.tails must be Molecule or list of Molecules')
+        
+        self.hg = hg
+
+dopc = Lipid()
+nSL, nSL2 = dopc.hg.Hsld * dopc.hg.cell_volume, dopc.hg.Dsld * dopc.hg.cell_volume
+print(nSL, nSL2)
+

--- a/molgroups.py
+++ b/molgroups.py
@@ -606,7 +606,7 @@ def _unpack_lipids(self, lipids, xray_wavelength=None):
             self.nsl_acyl_lipids[i] = xray_sld(lipid.tails.formula, wavelength=xray_wavelength)[0] * lipid.tails.cell_volume * 1e-6
             self.nsl_methyl_lipids[i] = xray_sld(lipid.methyls.formula, wavelength=xray_wavelength)[0] * lipid.methyls.cell_volume * 1e-6
 
-class BLM_arbitrary(CompositenSLDObj):
+class BLM(CompositenSLDObj):
     def __init__(self, lipids=[DOPC], lipid_nf=[1.0], xray_wavelength=None, **kwargs):
         super().__init__(**kwargs)
         assert len(lipids)==len(lipid_nf), 'List of lipids and number fractions must be of equal length, not %i and %i' % (len(lipids), len(lipid_nf))
@@ -778,7 +778,8 @@ class BLM_arbitrary(CompositenSLDObj):
         #self.defect_headgroup.vol = defectratio * (self.headgroup2.vol * self.headgroup2.nf + self.headgroup2_2.vol * self.headgroup2_2.nf + self.headgroup2_3.vol * self.headgroup2_3.nf)
         self.defect_headgroup.vol = defectratio * numpy.sum([hg.nf * hg.vol for hg in self.headgroups2])
         self.defect_headgroup.l = hclength + hglength
-        self.defect_headgroup.z = self.headgroups1[0].fnGetZ() - 0.5 * self.headgroups1[0].l + 0.5 * (hclength + hglength)
+        #self.defect_headgroup.z = self.headgroups1[0].fnGetZ() - 0.5 * self.headgroups1[0].l + 0.5 * (hclength + hglength)
+        self.defect_headgroup.z = self.lipid1.z - 0.5 * self.lipid1.l - 0.5 * self.av_hg1_l + 0.5 * (hclength + hglength)
         self.defect_headgroup.nSL = defectratio * numpy.sum([hg.nf * hg.fnGetnSL(self.bulknsld) for hg in self.headgroups2])
         #self.defect_headgroup.nSL = defectratio * (self.headgroup2.fnGetnSL()*self.headgroup2.nf * self.headgroup2.nf + self.headgroup2_2.fnGetnSL(self.bulknsld) * self.headgroup2_2.nf + self.headgroup2_3.fnGetnSL(self.bulknsld) * self.headgroup2_3.nf)
         self.defect_headgroup.fnSetSigma(self.sigma)
@@ -1586,7 +1587,7 @@ class ssBLM_quaternary(CompositenSLDObj):
         super().fnWritePar2File(fp, cName, z)
         self.fnWriteConstant(fp, "normarea", self.normarea, 0, z)
 
-class ssBLM_arbitrary(BLM_arbitrary):
+class ssBLM(BLM):
     def __init__(self, **kwargs):
 
         # add ssBLM-specific subgroups
@@ -2074,7 +2075,7 @@ class tBLM_quaternary(CompositenSLDObj):
         self.fnWriteConstant(fp, "normarea", self.normarea, 0, z)
 
 
-class tBLM_arbitrary(BLM_arbitrary):
+class tBLM(BLM):
     def __init__(self, tether=HC18, filler=bme, xray_wavelength=None, **kwargs):
 
         # add ssBLM-specific subgroups

--- a/molgroups.py
+++ b/molgroups.py
@@ -325,7 +325,8 @@ Dmethyl = Molecule(name='Dmethyl', formula='CD3', cell_volume=98.8/2.0)
 # Tether components
 SAc = Molecule(name='thiol acetate', formula = 'C2H3OS', cell_volume=117.0)
 EO6 = Molecule(name='6x ethylene oxide', formula='(C2H4O)6', cell_volume=360.0)
-tetherg = Molecule(name='tether glycerol', formula='C5H9O2', cell_volume=125.40)
+tetherg_ether = Molecule(name='tether glycerol ether', formula='C5H9O2', cell_volume=125.40)
+tetherg_ester = carbonyl_glycerol
 bmeSAc = Molecule(name='beta-mercaptoethanol thiol acetate', formula='C2H5O' + str(SAc.formula), cell_volume=97.0 + SAc.cell_volume)
 bme = Molecule(name='beta-mercaptoethanol', formula='C2H5OS', cell_volume=117.0)
 SEO6 = Molecule(name='EO6 S', formula=str(EO6.formula) + 'S', cell_volume=25.75 + EO6.cell_volume)
@@ -503,8 +504,8 @@ class Tether(Lipid):
     """Subclass of Lipid for use with tether molecules.
         Use hg field for tether glycerol.
         Tether includes both volume from """
-    def __init__(self, tether=SEO6, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, tether=SEO6, hg=tetherg_ether, **kwargs):
+        super().__init__(hg=hg, **kwargs)
         self.tether = tether
 
 
@@ -513,9 +514,9 @@ POPC = Lipid(name='POPC', hg=PC, tails=[palmitoyl, oleoyl])
 DOPS = Lipid(name='DOPS', hg=ps, tails=2*[oleoyl])
 chol = Lipid(name='chol', hg=None, tails=[cholesterol], methyls=None)
 
-HC18 = Tether(name='HC18', tether=SEO6, hg=tetherg, tails=[oleoyl, oleoyl])
-
-HC18SAc = Tether(name='HC18SAc', tether=SAcEO6, hg=tetherg, tails=[oleoyl, oleoyl])
+WC14 = Tether(name='WC14', tether=SEO6, hg=tetherg_ether, tails=[myristoyl, myristoyl])
+HC18 = Tether(name='HC18', tether=SEO6, hg=tetherg_ether, tails=[oleoyl, oleoyl])
+HC18SAc = Tether(name='HC18SAc', tether=SAcEO6, hg=tetherg_ether, tails=[oleoyl, oleoyl])
 
 # ------------------------------------------------------------------------------------------------------
 # Lipid Bilayer

--- a/molgroups.py
+++ b/molgroups.py
@@ -478,7 +478,7 @@ class PCm(PC):
 #       If tether is None but substrate exists, it's a ssBLM. "filler" is some material that the substrate is decorated with like bME.
 
 class Lipid(object):
-    def __init__(self, name=None, hg=PC, tails=[oleoyl, oleoyl], methyls=methyl):
+    def __init__(self, name=None, headgroup=PC, tails=[oleoyl, oleoyl], methyls=methyl):
         # hg = Molecule object with headgroup information or PC molgroups object
         # tails = List of molecule objects containing lipid tail information
         # methyls = List of methyl groups, one for each lipid tail; OR, a single group
@@ -487,6 +487,7 @@ class Lipid(object):
         # default is DOPC using the PC class.
         
         n_tails = len(tails)
+        self.name = name
 
         # tails section
         if isinstance(tails, list):
@@ -499,7 +500,7 @@ class Lipid(object):
             raise TypeError('Lipid.tails must be Molecule or list of Molecules')
         
         # headgroup
-        self.hg = hg if hg is not None else Component(name='', formula = '', cell_volume=0.0, length=9.575)
+        self.headgroup = headgroup if headgroup is not None else Component(name='', formula = '', cell_volume=0.0, length=9.575)
 
         # Create methyl groups
         if isinstance(methyls, list):
@@ -515,21 +516,22 @@ class Lipid(object):
 
 class Tether(Lipid):
     """Subclass of Lipid for use with tether molecules.
-        Use hg field for tether glycerol.
+        Uses hg field for tether glycerol.
         Tether includes both volume from """
-    def __init__(self, tether=SEO6, hg=tetherg_ether, **kwargs):
-        super().__init__(hg=hg, **kwargs)
+    def __init__(self, tether=SEO6, tetherg=tetherg_ether, **kwargs):
+        super().__init__(headgroup=tetherg, **kwargs)
         self.tether = tether
+        self.tetherg = self.headgroup
 
 
-DOPC = Lipid(name='DOPC', hg=PC, tails=2*[oleoyl])
-POPC = Lipid(name='POPC', hg=PC, tails=[palmitoyl, oleoyl])
-DOPS = Lipid(name='DOPS', hg=ps, tails=2*[oleoyl])
-chol = Lipid(name='chol', hg=None, tails=[cholesterol], methyls=None)
+DOPC = Lipid(name='DOPC', headgroup=PC, tails=2*[oleoyl])
+POPC = Lipid(name='POPC', headgroup=PC, tails=[palmitoyl, oleoyl])
+DOPS = Lipid(name='DOPS', headgroup=ps, tails=2*[oleoyl])
+chol = Lipid(name='chol', headgroup=None, tails=[cholesterol], methyls=None)
 
-WC14 = Tether(name='WC14', tether=SEO6, hg=tetherg_ether, tails=[myristoyl, myristoyl])
-HC18 = Tether(name='HC18', tether=SEO6, hg=tetherg_ether, tails=[oleoyl, oleoyl])
-HC18SAc = Tether(name='HC18SAc', tether=SAcEO6, hg=tetherg_ether, tails=[oleoyl, oleoyl])
+WC14 = Tether(name='WC14', tether=SEO6, tetherg=tetherg_ether, tails=[myristoyl, myristoyl])
+HC18 = Tether(name='HC18', tether=SEO6, tetherg=tetherg_ether, tails=[oleoyl, oleoyl])
+HC18SAc = Tether(name='HC18SAc', tether=SAcEO6, tetherg=tetherg_ether, tails=[oleoyl, oleoyl])
 
 # ------------------------------------------------------------------------------------------------------
 # Lipid Bilayer
@@ -564,14 +566,14 @@ def _unpack_lipids(self, lipids):
         ihg_name = 'headgroup1_%i' % (i+1)
         ohg_name = 'headgroup2_%i' % (i+1)
 
-        if isinstance(lipid.hg, Component):
+        if isinstance(lipid.headgroup, Component):
             # populates nSL, nSL2, vol, and l
             ihg_obj = Component2Box(name=ihg_name, molecule=lipid.hg)
             ohg_obj = Component2Box(name=ohg_name, molecule=lipid.hg)
 
-        elif issubclass(lipid.hg, CompositenSLDObj):
-            ihg_obj = lipid.hg(name=ihg_name, innerleaflet=True)
-            ohg_obj = lipid.hg(name=ohg_name, innerleaflet=False)
+        elif issubclass(lipid.headgroup, CompositenSLDObj):
+            ihg_obj = lipid.headgroup(name=ihg_name, innerleaflet=True)
+            ohg_obj = lipid.headgroup(name=ohg_name, innerleaflet=False)
 
         else:
             raise TypeError('Lipid.hg must be a Headgroup object or a subclass of CompositenSLDObj')
@@ -2071,7 +2073,7 @@ class tBLM_arbitrary(BLM_arbitrary):
         # change these to Headgroup2Box
         self.bME = Component2Box(name='bME', molecule=Component(name='bME', formula=filler.formula, cell_volume=filler.cell_volume, length=5.2))
         self.tether = Component2Box(name='tether', molecule=Component(name='tether', formula=tether.tether.formula, cell_volume=tether.tether.cell_volume, length=self.l_tether))
-        self.tetherg = Component2Box(name='tetherg', molecule=Component(name='tetherg', formula=tether.hg.formula, cell_volume=tether.hg.cell_volume, length=10.0))
+        self.tetherg = Component2Box(name='tetherg', molecule=Component(name='tetherg', formula=tether.tetherg.formula, cell_volume=tether.tetherg.cell_volume, length=10.0))
 
         self.substrate.l = 40
         self.substrate.z = 0

--- a/molgroups.py
+++ b/molgroups.py
@@ -491,6 +491,7 @@ class Lipid(object):
         self.methyls = Molecule(name='methyls', formula = methylformula, cell_volume=methylvolsum)
 
 DOPC = Lipid(name='DOPC', hg=PC, tails=2*[oleoyl])
+DOPS = Lipid(name='DOPS', hg=ps, tails=2*[oleoyl])
 chol = Lipid(name='chol', hg=None, tails=[cholesterol], methyls=None)
 
 # ------------------------------------------------------------------------------------------------------
@@ -532,7 +533,7 @@ class BLM_arbitrary(CompositenSLDObj):
             else:
                 raise TypeError('Lipid.hg must be a Headgroup object or a subclass of CompositenSLDObj')
 
-            # Note that because there's always one lipid, the objects headgroup1_1 and headgroup1_2 always exist (and are used later)
+            # Note that because there's always one lipid, the objects self.headgroups1[0] and self.headgroups2[0] always exist
             self.__setattr__(ihg_name, ihg_obj)
             self.headgroups1.append(self.__getattribute__(ihg_name))
             self.__setattr__(ohg_name, ohg_obj)
@@ -589,7 +590,7 @@ class BLM_arbitrary(CompositenSLDObj):
         nf_ohc_lipid = self.lipid_nf
         V_ohc = numpy.sum(nf_ohc_lipid * (self.vol_acyl_lipids - self.vol_methyl_lipids))
         nSL_ohc = numpy.sum(nf_ohc_lipid * (self.nsl_acyl_lipids - self.nsl_methyl_lipids))
-#        V_ohc = nf_ohc_lipid * (self.volacyllipid - self.volmethyllipid) + nf_ohc_lipid_2 * (self.volacyllipid_2 - self.volmethyllipid_2) + nf_ohc_lipid_3 * (self.volacyllipid_3 - self.volmethyllipid_3) + nf_ohc_chol * self.volchol
+        #V_ohc = nf_ohc_lipid * (self.volacyllipid - self.volmethyllipid) + nf_ohc_lipid_2 * (self.volacyllipid_2 - self.volmethyllipid_2) + nf_ohc_lipid_3 * (self.volacyllipid_3 - self.volmethyllipid_3) + nf_ohc_chol * self.volchol
         #nSL_ohc = nf_ohc_lipid * (self.nslacyllipid - self.nslmethyllipid) + nf_ohc_lipid_2 * (self.nslacyllipid_2 - self.nslmethyllipid_2) + nf_ohc_lipid_3 * (self.nslacyllipid_3 - self.nslmethyllipid_3) + nf_ohc_chol * self.nslchol
         
         self.normarea = V_ohc / l_ohc
@@ -702,10 +703,10 @@ class BLM_arbitrary(CompositenSLDObj):
         
         defectratio = self.defect_hydrocarbon.vol / self.lipid2.vol
         #self.defect_headgroup.vol = defectratio * (self.headgroup2.vol * self.headgroup2.nf + self.headgroup2_2.vol * self.headgroup2_2.nf + self.headgroup2_3.vol * self.headgroup2_3.nf)
-        self.defect_headgroup.vol = defectratio * sum([h.nf * h.vol for h in self.headgroups2])
+        self.defect_headgroup.vol = defectratio * numpy.sum([hg.nf * hg.vol for hg in self.headgroups2])
         self.defect_headgroup.l = hclength + hglength
         self.defect_headgroup.z = self.headgroups1[0].fnGetZ() - 0.5 * self.headgroups1[0].l + 0.5 * (hclength + hglength)
-        self.defect_headgroup.nSL = defectratio * sum([h.nf * h.fnGetnSL(self.bulknsld) for h in self.headgroups2])
+        self.defect_headgroup.nSL = defectratio * numpy.sum([hg.nf * hg.fnGetnSL(self.bulknsld) for hg in self.headgroups2])
         #self.defect_headgroup.nSL = defectratio * (self.headgroup2.fnGetnSL()*self.headgroup2.nf * self.headgroup2.nf + self.headgroup2_2.fnGetnSL(self.bulknsld) * self.headgroup2_2.nf + self.headgroup2_3.fnGetnSL(self.bulknsld) * self.headgroup2_3.nf)
         self.defect_headgroup.fnSetSigma(self.sigma)
         self.defect_headgroup.nf = 1

--- a/molgroups.py
+++ b/molgroups.py
@@ -272,8 +272,71 @@ class Box2Err(nSLDObj):
         self.fnWriteData2File(fp, cName, z)
 
 # ------------------------------------------------------------------------------------------------------
-# Headgroups
+# Lipids and headgroups
 # ------------------------------------------------------------------------------------------------------
+
+from periodictable.fasta import Molecule
+# in formulas, use H[1] for exchangeable hydrogens, then Molecule.sld, Molecule.Dsld
+# to get limiting slds, or Molecule.D2Osld(D2O_fraction=??) to get arbitrary D2O fraction.
+
+class Headgroup(Molecule):
+    # Subclasses Molecule to automatically store a headgroup length for use later
+    # and calculate total scattering lengths
+    def __init__(self, length=9.575, **kwargs):
+        super().__init__(**kwargs)
+        self.length = length
+        self.nSL = self.sld * self.cell_volume * 1e-6 # units of Ang
+        self.DnSL = self.Dsld * self.cell_volume * 1e-6 # units of Ang
+
+def Headgroup2Box(name=None, molecule=None):
+    # Creates a new Box2Err from Headgroup data
+
+    box = Box2Err(name=name, dvolume=molecule.cell_volume, dlength=molecule.length)
+    box.fnSetnSL(molecule.sld * molecule.cell_volume * 1e-6, molecule.Dsld * molecule.cell_volume * 1e-6)
+
+    return box
+
+# PC headgroup pieces
+choline = Headgroup(name='choline', formula='C5 H13 N', cell_volume=120., length=6.34)
+phosphate = Headgroup(name='phosphate', formula='PO4', cell_volume=54., length=3.86)
+carbonyl_glycerol = Headgroup(name='carbonyl + glycerol', formula='C5 O4 H5', cell_volume=147., length=4.21)
+
+# standard headgroups
+pc = Headgroup(name='pc', formula='C10 H18 O8 N P', cell_volume=331.00, length=9.575)
+pe = Headgroup(name='pe', formula='C7 H9 H[1]3 O8 N P', cell_volume=262., length=7.7)
+pg = Headgroup(name='pg', formula='C8 H10 H[1]2 O10 P', cell_volume=240., length=7.8)
+ps = Headgroup(name='ps', formula='C8 H8 H[1]3 N O10 P', cell_volume=280., length=8.1)
+pa = Headgroup(name='pa', formula='C5 H5 H[1] O8 P', cell_volume=174., length=5.0)
+pi = Headgroup(name='pi', formula='C11 H7 H[1]5 O13 P', cell_volume=370.7, length=10.7)
+pip2 = Headgroup(name='pi(4,5)p2', formula='C11 H7 H[1]5 O19 P3', cell_volume=500., length=12.0) # doesn't match molgroups.cc
+cardiolipin = Headgroup(name='cardiolipin', formula='C13 H15 H[1] O17 P2', cell_volume=684.4, length=9.56)
+
+# standard acyl chains
+oleoyl = Molecule(name='oleoyl', formula='C17 H33', cell_volume=474.90/2.0)
+palmitoyl = Molecule(name='palmitoyl', formula='C15 H31', cell_volume=770./2.0)
+myristoyl = Molecule(name='myristoyl', formula='C13 H27', cell_volume=770./2.0)
+phytanoyl = Molecule(name='phytanoyl', formula='C19 H39', cell_volume=1095./2.0)
+
+# TODO: make a Tether class that can be passed to tethered bilayers. Perhaps make Tether class none for supported bilayers?
+
+class Lipid(object):
+    def __init__(self, name=None, hg=pc, tails=[oleoyl, oleoyl], **kwargs):
+        # hg = Molecule object with headgroup information or PC molgroups object
+        # tails = List of molecule objects containing lipid tail information
+        # default is DOPC
+       
+        # tails section
+        tail_volume = sum([t.cell_volume for t in tails])
+        if isinstance(tails, list):
+            tail_formula = ' '.join([str(t.formula) for t in tails])
+            self.tails = Molecule(name='tails',formula=tail_formula, cell_volume=tail_volume)
+        elif isinstance(tails, Molecule):
+            self.tails = tails
+        else:
+            raise TypeError('Lipid.tails must be Molecule or list of Molecules')
+        
+        self.hg = hg
+        assert (isinstance(hg, Molecule) | isinstance(hg, CompositenSLDObj)), 'Lipid.hg must be of type Headgroup or CompositenSLDObj'
 
 # TODO: A headgroup class must contain an "innerleaflet" flag that determines whether the headgroup
 # is in the inner or outer leaflet. The profiles so obtained should be flipped. This should perhaps
@@ -285,25 +348,13 @@ class PC(CompositenSLDObj):
         # innerleaflet flag locates it in the inner leaflet and flips the order of cg, phosphate,
         # and choline groups. If False, it's the outer leaflet
         super().__init__(**kwargs)
-        self.cg = Box2Err(name='cg')
-        self.phosphate = Box2Err(name='phosphate')
-        self.choline = Box2Err(name='choline')
+        self.cg = Headgroup2Box(name='cg', molecule=carbonyl_glycerol)
+        self.phosphate = Headgroup2Box(name='phosphate', molecule=phosphate)
+        self.choline = Headgroup2Box(name='choline', molecule=choline)
         
         self.innerleaflet = innerleaflet
 
         self.groups = {"cg": self.cg, "phosphate": self.phosphate, "choline": self.choline}
-
-        self.cg.l = 4.21 
-        self.cg.vol=147 
-        self.cg.nSL=3.7755e-4
-
-        self.phosphate.l = 3.86
-        self.phosphate.vol=54 
-        self.phosphate.nSL=2.8350e-4 
-
-        self.choline.l = 6.34
-        self.choline.vol=120
-        self.choline.nSL=-6.0930e-5
 
         if innerleaflet:
 
@@ -343,6 +394,7 @@ class PC(CompositenSLDObj):
             self.phosphate.z = z0 + (z1 - z0) * self.ph_relative_pos
     
     def fnSet(self, l=9.575, ph_relative_pos=.5, cg_nSL=1.885e-3, ch_nSL=1.407e-3, ph_nSL=1.323e-3):
+        # TODO: these overwrite the known nSL parameters. Do we really want to do that here?
         self.cg.nSL = cg_nSL
         self.choline.nSL = ch_nSL
         self.phosphate.nSL = ph_nSL

--- a/molgroups.py
+++ b/molgroups.py
@@ -313,13 +313,13 @@ phosphate = Component(name='phosphate', formula='PO4', cell_volume=54., length=3
 carbonyl_glycerol = Component(name='carbonyl + glycerol', formula='C5 O4 H5', cell_volume=147., length=4.21)
 
 # standard headgroups
-pc = Component(name='pc', formula='C10 H18 O8 N P', cell_volume=331.00, length=9.575)
-pe = Component(name='pe', formula='C7 H9 H[1]3 O8 N P', cell_volume=262., length=7.7)
-pg = Component(name='pg', formula='C8 H10 H[1]2 O10 P', cell_volume=240., length=7.8)
-ps = Component(name='ps', formula='C8 H8 H[1]3 N O10 P', cell_volume=280., length=8.1)
-pa = Component(name='pa', formula='C5 H5 H[1] O8 P', cell_volume=174., length=5.0)
-pi = Component(name='pi', formula='C11 H7 H[1]5 O13 P', cell_volume=370.7, length=10.7)
-pip2 = Component(name='pi(4,5)p2', formula='C11 H7 H[1]5 O19 P3', cell_volume=500., length=12.0) # doesn't match molgroups.cc
+pc = Component(name='PC', formula='C10 H18 O8 N P', cell_volume=331.00, length=9.575)
+pe = Component(name='PE', formula='C7 H9 H[1]3 O8 N P', cell_volume=262., length=7.7)
+pg = Component(name='PG', formula='C8 H10 H[1]2 O10 P', cell_volume=240., length=7.8)
+ps = Component(name='PS', formula='C8 H8 H[1]3 N O10 P', cell_volume=280., length=8.1)
+pa = Component(name='PA', formula='C5 H5 H[1] O8 P', cell_volume=174., length=5.0)
+pi = Component(name='PI', formula='C11 H7 H[1]5 O13 P', cell_volume=370.7, length=10.7)
+pip2 = Component(name='PI(4,5)P2', formula='C11 H7 H[1]5 O19 P3', cell_volume=500., length=12.0) # doesn't match molgroups.cc
 cardiolipin = Component(name='cardiolipin', formula='C13 H15 H[1] O17 P2', cell_volume=684.4, length=9.56)
 
 # standard acyl chains


### PR DESCRIPTION
Leverages the periodictable.fasta library (https://github.com/pkienzle/periodictable) to specify molecular components as "Molecule" objects or their derivative "Component" (includes length) objects.

New Component, Lipid, and Tether classes.
BLM models (BLM, ssBLM, tBLM) are now all instances of the base BLM class.
