### PR TITLE
add conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+# environment.yml
+name: molgroups310
+channels:
+ - conda-forge
+dependencies:
+ - python==3.10
+ - dill
+ - ipython
+ - jupyterlab
+ - matplotlib
+ - mdanalysis
+ - numpy
+ - periodictable
+ - pip
+ - pandas
+ - scikit-learn
+ - scipy
+ - setuptools
+ - pip:
+   - bumps
+   - refl1d
+   - sasdata
+   - sasmodels


### PR DESCRIPTION
Add a conda environment file for convenience. Allows single line setup, e.g.

```
conda env create -n molgroups310 --file environment.yml
```