### PR TITLE
Boxhermite

### DIFF
--- a/molgroups/mol.py
+++ b/molgroups/mol.py
@@ -2017,14 +2017,14 @@ class BoxHermite(Hermite):
         Note that this may behave badly if sigma is more than about 1/2 the control point spacing.
     """
 
-    def __init__(self, dnormarea=60, name='boxhermite'):
+    def __init__(self, dnormarea=60, n_box=21, name='boxhermite'):
         super().__init__(dnormarea, name)
 
         # width of spline at previous interface
         self.sigma = 2.0
 
         # set number of control points for box. n = 9 keeps errors below 0.1 % (empirically)
-        self.n_box = 21
+        self.n_box = n_box
 
     def _get_box_spline(self):
         # finds extra control points corresponding to a generic error function with width sigma

--- a/molgroups/mol.py
+++ b/molgroups/mol.py
@@ -188,7 +188,11 @@ class nSLDObj:
                 print('Scalar-defined interval for area calculation requires using a stored profile')
                 sys.exit(1)
             else:
-                zaxis_gradient = numpy.gradient(self.zaxis[numpy.where((z1 <= self.zaxis) & (self.zaxis <= z2))])
+                z_interval = self.zaxis[numpy.where((z1 <= self.zaxis) & (self.zaxis <= z2))]
+                if len(z_interval) > 1:
+                    zaxis_gradient = numpy.gradient(z_interval)
+                else:
+                    return 0.0
         return numpy.sum(area * zaxis_gradient)
 
     def fnGetZ(self):


### PR DESCRIPTION
Adds a BoxHermite object. The first control points are used to define the first half of an error function, then, the usual Hermite properties take over. The height of the object at the start position is then 0.5 times the first control point volume fraction

Allows straightforward interfacing to error functions without overfilling space.